### PR TITLE
Add restaurant status enum

### DIFF
--- a/src/main/java/club/castillo/restaurantes/controller/RestaurantController.java
+++ b/src/main/java/club/castillo/restaurantes/controller/RestaurantController.java
@@ -3,6 +3,7 @@ package club.castillo.restaurantes.controller;
 import club.castillo.restaurantes.dto.RestaurantRequestDTO;
 import club.castillo.restaurantes.dto.RestaurantResponseDTO;
 import club.castillo.restaurantes.service.RestaurantService;
+import club.castillo.restaurantes.model.RestaurantStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -47,8 +48,15 @@ public class RestaurantController {
 
     @GetMapping("/status/{status}")
     public ResponseEntity<List<RestaurantResponseDTO>> getRestaurantsByStatus(
-            @PathVariable String status) {
+            @PathVariable RestaurantStatus status) {
         return ResponseEntity.ok(restaurantService.getRestaurantsByStatus(status));
+    }
+
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<RestaurantResponseDTO> updateRestaurantStatus(
+            @PathVariable Long id,
+            @RequestParam RestaurantStatus status) {
+        return ResponseEntity.ok(restaurantService.updateRestaurantStatus(id, status));
     }
 
     @PatchMapping("/{id}/disable")

--- a/src/main/java/club/castillo/restaurantes/dto/RestaurantRequestDTO.java
+++ b/src/main/java/club/castillo/restaurantes/dto/RestaurantRequestDTO.java
@@ -3,6 +3,7 @@ package club.castillo.restaurantes.dto;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
+import club.castillo.restaurantes.model.RestaurantStatus;
 
 @Getter
 @Setter
@@ -14,5 +15,5 @@ public class RestaurantRequestDTO {
 
     private Long managerId;
 
-    private String status; // abierto/cerrado
+    private RestaurantStatus status; // abierto/cerrado
 }

--- a/src/main/java/club/castillo/restaurantes/dto/RestaurantResponseDTO.java
+++ b/src/main/java/club/castillo/restaurantes/dto/RestaurantResponseDTO.java
@@ -2,6 +2,7 @@ package club.castillo.restaurantes.dto;
 
 import lombok.Builder;
 import lombok.Data;
+import club.castillo.restaurantes.model.RestaurantStatus;
 
 @Data
 @Builder
@@ -9,7 +10,7 @@ public class RestaurantResponseDTO {
     private Long id;
     private String name;
     private String address;
-    private String status;
+    private RestaurantStatus status;
     private Boolean active;
     private ManagerDTO manager;
 

--- a/src/main/java/club/castillo/restaurantes/model/Restaurant.java
+++ b/src/main/java/club/castillo/restaurantes/model/Restaurant.java
@@ -4,6 +4,10 @@ import jakarta.persistence.*;
 import lombok.*;
 import java.util.List;
 
+/**
+ * Restaurant entity.
+ */
+
 @Entity
 @Table(name = "restaurants")
 @Data
@@ -25,7 +29,8 @@ public class Restaurant {
     private User manager;
 
     @Column(length = 20)
-    private String status = "closed";
+    @Enumerated(EnumType.STRING)
+    private RestaurantStatus status = RestaurantStatus.CLOSED;
 
     @OneToMany(mappedBy = "restaurant")
     private List<RestaurantTable> tables;

--- a/src/main/java/club/castillo/restaurantes/model/RestaurantStatus.java
+++ b/src/main/java/club/castillo/restaurantes/model/RestaurantStatus.java
@@ -1,0 +1,6 @@
+package club.castillo.restaurantes.model;
+
+public enum RestaurantStatus {
+    OPEN,
+    CLOSED
+}

--- a/src/main/java/club/castillo/restaurantes/repository/RestaurantRepository.java
+++ b/src/main/java/club/castillo/restaurantes/repository/RestaurantRepository.java
@@ -1,11 +1,12 @@
 package club.castillo.restaurantes.repository;
 
 import club.castillo.restaurantes.model.Restaurant;
+import club.castillo.restaurantes.model.RestaurantStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
-    List<Restaurant> findByStatus(String status);
+    List<Restaurant> findByStatus(RestaurantStatus status);
     List<Restaurant> findByActiveTrue();
 }

--- a/src/main/java/club/castillo/restaurantes/service/RestaurantService.java
+++ b/src/main/java/club/castillo/restaurantes/service/RestaurantService.java
@@ -2,6 +2,7 @@ package club.castillo.restaurantes.service;
 
 import club.castillo.restaurantes.dto.RestaurantRequestDTO;
 import club.castillo.restaurantes.dto.RestaurantResponseDTO;
+import club.castillo.restaurantes.model.RestaurantStatus;
 
 import java.util.List;
 
@@ -13,5 +14,7 @@ public interface RestaurantService {
     RestaurantResponseDTO getRestaurantById(Long id);
     List<RestaurantResponseDTO> getAllRestaurants();
     List<RestaurantResponseDTO> getAllActiveRestaurants();
-    List<RestaurantResponseDTO> getRestaurantsByStatus(String status);
+    List<RestaurantResponseDTO> getRestaurantsByStatus(RestaurantStatus status);
+
+    RestaurantResponseDTO updateRestaurantStatus(Long id, RestaurantStatus status);
 }

--- a/src/main/java/club/castillo/restaurantes/service/impl/RestaurantServiceImpl.java
+++ b/src/main/java/club/castillo/restaurantes/service/impl/RestaurantServiceImpl.java
@@ -3,6 +3,7 @@ package club.castillo.restaurantes.service.impl;
 import club.castillo.restaurantes.dto.RestaurantRequestDTO;
 import club.castillo.restaurantes.dto.RestaurantResponseDTO;
 import club.castillo.restaurantes.model.Restaurant;
+import club.castillo.restaurantes.model.RestaurantStatus;
 import club.castillo.restaurantes.model.User;
 import club.castillo.restaurantes.repository.RestaurantRepository;
 import club.castillo.restaurantes.repository.UserRepository;
@@ -29,7 +30,7 @@ public class RestaurantServiceImpl implements RestaurantService {
         Restaurant restaurant = new Restaurant();
         restaurant.setName(requestDTO.getName());
         restaurant.setAddress(requestDTO.getAddress());
-        restaurant.setStatus(Optional.ofNullable(requestDTO.getStatus()).orElse("closed"));
+        restaurant.setStatus(Optional.ofNullable(requestDTO.getStatus()).orElse(RestaurantStatus.CLOSED));
         restaurant.setActive(true);
 
         if (requestDTO.getManagerId() != null) {
@@ -104,10 +105,19 @@ public class RestaurantServiceImpl implements RestaurantService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<RestaurantResponseDTO> getRestaurantsByStatus(String status) {
+    public List<RestaurantResponseDTO> getRestaurantsByStatus(RestaurantStatus status) {
         return restaurantRepository.findByStatus(status).stream()
                 .map(this::mapToResponseDTO)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public RestaurantResponseDTO updateRestaurantStatus(Long id, RestaurantStatus status) {
+        Restaurant restaurant = restaurantRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Restaurante no encontrado"));
+        restaurant.setStatus(status);
+        Restaurant saved = restaurantRepository.save(restaurant);
+        return mapToResponseDTO(saved);
     }
 
     private RestaurantResponseDTO mapToResponseDTO(Restaurant restaurant) {


### PR DESCRIPTION
## Summary
- introduce `RestaurantStatus` enum
- use enum for status in `Restaurant`
- update DTOs, repository, service and controller
- add endpoint to patch restaurant status

## Testing
- `./mvnw -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68515ac2f9e88325acc7b3d408de64b9