### PR TITLE
Add CRUD operations for menus

### DIFF
--- a/src/main/java/club/castillo/restaurantes/controller/MenuController.java
+++ b/src/main/java/club/castillo/restaurantes/controller/MenuController.java
@@ -1,10 +1,14 @@
 package club.castillo.restaurantes.controller;
 
 import club.castillo.restaurantes.dto.MenuResponseDTO;
+import club.castillo.restaurantes.dto.MenuRequestDTO;
+import club.castillo.restaurantes.dto.MenuAdminResponseDTO;
 import club.castillo.restaurantes.service.MenuService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 
 import java.util.Optional;
 
@@ -28,4 +32,36 @@ public class MenuController {
                 Optional.ofNullable(maxPrice),
                 Optional.ofNullable(searchTerm)));
     }
-} 
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<MenuAdminResponseDTO> createMenu(@RequestBody @Valid MenuRequestDTO request) {
+        return ResponseEntity.ok(menuService.createMenu(request));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<MenuAdminResponseDTO> updateMenu(
+            @PathVariable Long id,
+            @RequestBody @Valid MenuRequestDTO request) {
+        return ResponseEntity.ok(menuService.updateMenu(id, request));
+    }
+
+    @PostMapping("/{id}/products/{productId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> assignProduct(
+            @PathVariable Long id,
+            @PathVariable Long productId) {
+        menuService.assignProduct(id, productId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{id}/products/{productId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> unassignProduct(
+            @PathVariable Long id,
+            @PathVariable Long productId) {
+        menuService.unassignProduct(id, productId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/club/castillo/restaurantes/dto/MenuAdminResponseDTO.java
+++ b/src/main/java/club/castillo/restaurantes/dto/MenuAdminResponseDTO.java
@@ -1,0 +1,39 @@
+package club.castillo.restaurantes.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MenuAdminResponseDTO {
+    private Long id;
+    private String name;
+    private String description;
+    private Boolean active;
+    private RestaurantDTO restaurant;
+    private List<ProductDTO> products;
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RestaurantDTO {
+        private Long id;
+        private String name;
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ProductDTO {
+        private Long id;
+        private String name;
+    }
+}

--- a/src/main/java/club/castillo/restaurantes/dto/MenuRequestDTO.java
+++ b/src/main/java/club/castillo/restaurantes/dto/MenuRequestDTO.java
@@ -1,0 +1,22 @@
+package club.castillo.restaurantes.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MenuRequestDTO {
+    @NotBlank(message = "El nombre del menú es requerido")
+    private String name;
+
+    private String description;
+
+    @NotNull(message = "El ID del restaurante es requerido")
+    private Long restaurantId;
+}

--- a/src/main/java/club/castillo/restaurantes/repository/MenuProductRepository.java
+++ b/src/main/java/club/castillo/restaurantes/repository/MenuProductRepository.java
@@ -3,5 +3,8 @@ package club.castillo.restaurantes.repository;
 import club.castillo.restaurantes.model.MenuProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MenuProductRepository extends JpaRepository<MenuProduct, Long> {
+    Optional<MenuProduct> findByMenuIdAndProductId(Long menuId, Long productId);
 }

--- a/src/main/java/club/castillo/restaurantes/repository/MenuRepository.java
+++ b/src/main/java/club/castillo/restaurantes/repository/MenuRepository.java
@@ -3,9 +3,15 @@ package club.castillo.restaurantes.repository;
 import club.castillo.restaurantes.model.Menu;
 import club.castillo.restaurantes.model.Restaurant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
     List<Menu> findByRestaurant(Restaurant restaurant);
+
+    @Query("SELECT m FROM Menu m LEFT JOIN FETCH m.products mp LEFT JOIN FETCH mp.product WHERE m.id = :id")
+    Optional<Menu> findByIdWithProducts(@Param("id") Long id);
 }

--- a/src/main/java/club/castillo/restaurantes/service/MenuService.java
+++ b/src/main/java/club/castillo/restaurantes/service/MenuService.java
@@ -1,6 +1,8 @@
 package club.castillo.restaurantes.service;
 
 import club.castillo.restaurantes.dto.MenuResponseDTO;
+import club.castillo.restaurantes.dto.MenuRequestDTO;
+import club.castillo.restaurantes.dto.MenuAdminResponseDTO;
 
 import java.util.Optional;
 
@@ -14,8 +16,16 @@ public interface MenuService {
      * @param searchTerm término de búsqueda para filtrar productos (opcional)
      * @return el menú del restaurante con sus categorías y productos
      */
-    MenuResponseDTO getRestaurantMenu(Long restaurantId, 
-                                    boolean showUnavailable, 
-                                    Optional<Double> maxPrice, 
+    MenuResponseDTO getRestaurantMenu(Long restaurantId,
+                                    boolean showUnavailable,
+                                    Optional<Double> maxPrice,
                                     Optional<String> searchTerm);
-} 
+
+    MenuAdminResponseDTO createMenu(MenuRequestDTO requestDTO);
+
+    MenuAdminResponseDTO updateMenu(Long id, MenuRequestDTO requestDTO);
+
+    void assignProduct(Long menuId, Long productId);
+
+    void unassignProduct(Long menuId, Long productId);
+}


### PR DESCRIPTION
## Summary
- add DTOs for menu requests and admin responses
- extend `MenuService` and implement logic for creating/updating menus and assigning products
- expose new endpoints in `MenuController`
- enhance menu repositories for product relations

## Testing
- `mvnw -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6851621bc9d88325b04d3b202b4610f1