### PR TITLE
Add services and controllers for customers

### DIFF
--- a/src/main/java/club/castillo/restaurantes/controller/CustomerController.java
+++ b/src/main/java/club/castillo/restaurantes/controller/CustomerController.java
@@ -1,0 +1,63 @@
+package club.castillo.restaurantes.controller;
+
+import club.castillo.restaurantes.dto.CustomerRequestDTO;
+import club.castillo.restaurantes.dto.CustomerResponseDTO;
+import club.castillo.restaurantes.service.CustomerService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/customers")
+@RequiredArgsConstructor
+public class CustomerController {
+
+    private final CustomerService customerService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<CustomerResponseDTO> createCustomer(@Valid @RequestBody CustomerRequestDTO request) {
+        return ResponseEntity.ok(customerService.createCustomer(request));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<CustomerResponseDTO> updateCustomer(
+            @PathVariable Long id,
+            @Valid @RequestBody CustomerRequestDTO request) {
+        return ResponseEntity.ok(customerService.updateCustomer(id, request));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<CustomerResponseDTO> getCustomer(@PathVariable Long id) {
+        return ResponseEntity.ok(customerService.getCustomerById(id));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CustomerResponseDTO>> getActiveCustomers() {
+        return ResponseEntity.ok(customerService.getAllActiveCustomers());
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<List<CustomerResponseDTO>> getAllCustomers() {
+        return ResponseEntity.ok(customerService.getAllCustomers());
+    }
+
+    @PatchMapping("/{id}/disable")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> disableCustomer(@PathVariable Long id) {
+        customerService.disableById(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{id}/enable")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> enableCustomer(@PathVariable Long id) {
+        customerService.enableById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/club/castillo/restaurantes/controller/CustomerTypeController.java
+++ b/src/main/java/club/castillo/restaurantes/controller/CustomerTypeController.java
@@ -1,0 +1,63 @@
+package club.castillo.restaurantes.controller;
+
+import club.castillo.restaurantes.dto.CustomerTypeRequestDTO;
+import club.castillo.restaurantes.dto.CustomerTypeResponseDTO;
+import club.castillo.restaurantes.service.CustomerTypeService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/customer-types")
+@RequiredArgsConstructor
+public class CustomerTypeController {
+
+    private final CustomerTypeService customerTypeService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<CustomerTypeResponseDTO> createCustomerType(@Valid @RequestBody CustomerTypeRequestDTO request) {
+        return ResponseEntity.ok(customerTypeService.createCustomerType(request));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<CustomerTypeResponseDTO> updateCustomerType(
+            @PathVariable Long id,
+            @Valid @RequestBody CustomerTypeRequestDTO request) {
+        return ResponseEntity.ok(customerTypeService.updateCustomerType(id, request));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<CustomerTypeResponseDTO> getCustomerType(@PathVariable Long id) {
+        return ResponseEntity.ok(customerTypeService.getCustomerTypeById(id));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CustomerTypeResponseDTO>> getActiveCustomerTypes() {
+        return ResponseEntity.ok(customerTypeService.getAllActiveCustomerTypes());
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<List<CustomerTypeResponseDTO>> getAllCustomerTypes() {
+        return ResponseEntity.ok(customerTypeService.getAllCustomerTypes());
+    }
+
+    @PatchMapping("/{id}/disable")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> disableCustomerType(@PathVariable Long id) {
+        customerTypeService.disableById(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{id}/enable")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> enableCustomerType(@PathVariable Long id) {
+        customerTypeService.enableById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/club/castillo/restaurantes/dto/CustomerRequestDTO.java
+++ b/src/main/java/club/castillo/restaurantes/dto/CustomerRequestDTO.java
@@ -1,0 +1,32 @@
+package club.castillo.restaurantes.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerRequestDTO {
+    @NotBlank(message = "El nombre del cliente es requerido")
+    private String name;
+
+    private String identification;
+
+    @Email(message = "El email debe ser válido")
+    private String email;
+
+    @NotNull(message = "El tipo de cliente es requerido")
+    private Long customerTypeId;
+
+    private String status;
+
+    private LocalDate joinedAt;
+}

--- a/src/main/java/club/castillo/restaurantes/dto/CustomerResponseDTO.java
+++ b/src/main/java/club/castillo/restaurantes/dto/CustomerResponseDTO.java
@@ -1,0 +1,32 @@
+package club.castillo.restaurantes.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerResponseDTO {
+    private Long id;
+    private String name;
+    private String identification;
+    private String email;
+    private String status;
+    private LocalDate joinedAt;
+    private Boolean active;
+    private CustomerTypeDTO customerType;
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CustomerTypeDTO {
+        private Long id;
+        private String name;
+    }
+}

--- a/src/main/java/club/castillo/restaurantes/dto/CustomerTypeRequestDTO.java
+++ b/src/main/java/club/castillo/restaurantes/dto/CustomerTypeRequestDTO.java
@@ -1,0 +1,16 @@
+package club.castillo.restaurantes.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerTypeRequestDTO {
+    @NotBlank(message = "El nombre del tipo de cliente es requerido")
+    private String name;
+}

--- a/src/main/java/club/castillo/restaurantes/dto/CustomerTypeResponseDTO.java
+++ b/src/main/java/club/castillo/restaurantes/dto/CustomerTypeResponseDTO.java
@@ -1,0 +1,16 @@
+package club.castillo.restaurantes.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomerTypeResponseDTO {
+    private Long id;
+    private String name;
+    private Boolean active;
+}

--- a/src/main/java/club/castillo/restaurantes/repository/CustomerRepository.java
+++ b/src/main/java/club/castillo/restaurantes/repository/CustomerRepository.java
@@ -2,8 +2,12 @@ package club.castillo.restaurantes.repository;
 
 import club.castillo.restaurantes.model.Customer;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
     Optional<Customer> findByIdentification(String identification);
+    boolean existsByIdentification(String identification);
+    List<Customer> findByActiveTrue();
 }

--- a/src/main/java/club/castillo/restaurantes/repository/CustomerTypeRepository.java
+++ b/src/main/java/club/castillo/restaurantes/repository/CustomerTypeRepository.java
@@ -3,6 +3,12 @@ package club.castillo.restaurantes.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import club.castillo.restaurantes.model.CustomerType;
 
+import java.util.List;
+import java.util.Optional;
+
 
 public interface CustomerTypeRepository extends JpaRepository<CustomerType, Long> {
+    Optional<CustomerType> findByName(String name);
+    boolean existsByName(String name);
+    List<CustomerType> findByActiveTrue();
 }

--- a/src/main/java/club/castillo/restaurantes/service/CustomerService.java
+++ b/src/main/java/club/castillo/restaurantes/service/CustomerService.java
@@ -1,0 +1,17 @@
+package club.castillo.restaurantes.service;
+
+import club.castillo.restaurantes.dto.CustomerRequestDTO;
+import club.castillo.restaurantes.dto.CustomerResponseDTO;
+
+import java.util.List;
+
+public interface CustomerService {
+    CustomerResponseDTO createCustomer(CustomerRequestDTO requestDTO);
+    CustomerResponseDTO updateCustomer(Long id, CustomerRequestDTO requestDTO);
+    void disableById(Long id);
+    void enableById(Long id);
+    CustomerResponseDTO getCustomerById(Long id);
+    List<CustomerResponseDTO> getAllCustomers();
+    List<CustomerResponseDTO> getAllActiveCustomers();
+    CustomerResponseDTO getCustomerByIdentification(String identification);
+}

--- a/src/main/java/club/castillo/restaurantes/service/CustomerTypeService.java
+++ b/src/main/java/club/castillo/restaurantes/service/CustomerTypeService.java
@@ -1,0 +1,17 @@
+package club.castillo.restaurantes.service;
+
+import club.castillo.restaurantes.dto.CustomerTypeRequestDTO;
+import club.castillo.restaurantes.dto.CustomerTypeResponseDTO;
+
+import java.util.List;
+
+public interface CustomerTypeService {
+    CustomerTypeResponseDTO createCustomerType(CustomerTypeRequestDTO requestDTO);
+    CustomerTypeResponseDTO updateCustomerType(Long id, CustomerTypeRequestDTO requestDTO);
+    void disableById(Long id);
+    void enableById(Long id);
+    CustomerTypeResponseDTO getCustomerTypeById(Long id);
+    List<CustomerTypeResponseDTO> getAllCustomerTypes();
+    List<CustomerTypeResponseDTO> getAllActiveCustomerTypes();
+    CustomerTypeResponseDTO getCustomerTypeByName(String name);
+}

--- a/src/main/java/club/castillo/restaurantes/service/impl/CustomerServiceImpl.java
+++ b/src/main/java/club/castillo/restaurantes/service/impl/CustomerServiceImpl.java
@@ -1,0 +1,136 @@
+package club.castillo.restaurantes.service.impl;
+
+import club.castillo.restaurantes.dto.CustomerRequestDTO;
+import club.castillo.restaurantes.dto.CustomerResponseDTO;
+import club.castillo.restaurantes.model.Customer;
+import club.castillo.restaurantes.model.CustomerType;
+import club.castillo.restaurantes.repository.CustomerRepository;
+import club.castillo.restaurantes.repository.CustomerTypeRepository;
+import club.castillo.restaurantes.service.CustomerService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CustomerServiceImpl implements CustomerService {
+
+    private final CustomerRepository customerRepository;
+    private final CustomerTypeRepository customerTypeRepository;
+
+    @Override
+    public CustomerResponseDTO createCustomer(CustomerRequestDTO requestDTO) {
+        if (requestDTO.getIdentification() != null &&
+                customerRepository.existsByIdentification(requestDTO.getIdentification())) {
+            throw new IllegalArgumentException("Ya existe un cliente con esa identificación");
+        }
+        CustomerType type = customerTypeRepository.findById(requestDTO.getCustomerTypeId())
+                .orElseThrow(() -> new EntityNotFoundException("Tipo de cliente no encontrado"));
+        Customer customer = Customer.builder()
+                .name(requestDTO.getName())
+                .identification(requestDTO.getIdentification())
+                .email(requestDTO.getEmail())
+                .customerType(type)
+                .status(Optional.ofNullable(requestDTO.getStatus()).orElse("active"))
+                .joinedAt(requestDTO.getJoinedAt())
+                .active(true)
+                .build();
+        Customer saved = customerRepository.save(customer);
+        return mapToDTO(saved);
+    }
+
+    @Override
+    public CustomerResponseDTO updateCustomer(Long id, CustomerRequestDTO requestDTO) {
+        Customer customer = customerRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Cliente no encontrado"));
+        if (requestDTO.getIdentification() != null &&
+                !requestDTO.getIdentification().equals(customer.getIdentification()) &&
+                customerRepository.existsByIdentification(requestDTO.getIdentification())) {
+            throw new IllegalArgumentException("Ya existe un cliente con esa identificación");
+        }
+        CustomerType type = customerTypeRepository.findById(requestDTO.getCustomerTypeId())
+                .orElseThrow(() -> new EntityNotFoundException("Tipo de cliente no encontrado"));
+        customer.setName(requestDTO.getName());
+        customer.setIdentification(requestDTO.getIdentification());
+        customer.setEmail(requestDTO.getEmail());
+        customer.setStatus(requestDTO.getStatus());
+        customer.setJoinedAt(requestDTO.getJoinedAt());
+        customer.setCustomerType(type);
+        Customer updated = customerRepository.save(customer);
+        return mapToDTO(updated);
+    }
+
+    @Override
+    public void disableById(Long id) {
+        Customer customer = customerRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Cliente no encontrado"));
+        customer.setActive(false);
+        customerRepository.save(customer);
+    }
+
+    @Override
+    public void enableById(Long id) {
+        Customer customer = customerRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Cliente no encontrado"));
+        customer.setActive(true);
+        customerRepository.save(customer);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CustomerResponseDTO getCustomerById(Long id) {
+        Customer customer = customerRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Cliente no encontrado"));
+        return mapToDTO(customer);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CustomerResponseDTO> getAllCustomers() {
+        return customerRepository.findAll().stream()
+                .map(this::mapToDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CustomerResponseDTO> getAllActiveCustomers() {
+        return customerRepository.findByActiveTrue().stream()
+                .map(this::mapToDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CustomerResponseDTO getCustomerByIdentification(String identification) {
+        Customer customer = customerRepository.findByIdentification(identification)
+                .orElseThrow(() -> new EntityNotFoundException("Cliente no encontrado"));
+        return mapToDTO(customer);
+    }
+
+    private CustomerResponseDTO mapToDTO(Customer customer) {
+        CustomerResponseDTO.CustomerTypeDTO typeDTO = null;
+        if (customer.getCustomerType() != null) {
+            typeDTO = CustomerResponseDTO.CustomerTypeDTO.builder()
+                    .id(customer.getCustomerType().getId())
+                    .name(customer.getCustomerType().getName())
+                    .build();
+        }
+        return CustomerResponseDTO.builder()
+                .id(customer.getId())
+                .name(customer.getName())
+                .identification(customer.getIdentification())
+                .email(customer.getEmail())
+                .status(customer.getStatus())
+                .joinedAt(customer.getJoinedAt())
+                .active(customer.getActive())
+                .customerType(typeDTO)
+                .build();
+    }
+}

--- a/src/main/java/club/castillo/restaurantes/service/impl/CustomerTypeServiceImpl.java
+++ b/src/main/java/club/castillo/restaurantes/service/impl/CustomerTypeServiceImpl.java
@@ -1,0 +1,104 @@
+package club.castillo.restaurantes.service.impl;
+
+import club.castillo.restaurantes.dto.CustomerTypeRequestDTO;
+import club.castillo.restaurantes.dto.CustomerTypeResponseDTO;
+import club.castillo.restaurantes.model.CustomerType;
+import club.castillo.restaurantes.repository.CustomerTypeRepository;
+import club.castillo.restaurantes.service.CustomerTypeService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CustomerTypeServiceImpl implements CustomerTypeService {
+
+    private final CustomerTypeRepository customerTypeRepository;
+
+    @Override
+    public CustomerTypeResponseDTO createCustomerType(CustomerTypeRequestDTO requestDTO) {
+        if (customerTypeRepository.existsByName(requestDTO.getName())) {
+            throw new IllegalArgumentException("Ya existe un tipo de cliente con ese nombre");
+        }
+        CustomerType customerType = CustomerType.builder()
+                .name(requestDTO.getName())
+                .active(true)
+                .build();
+        CustomerType saved = customerTypeRepository.save(customerType);
+        return mapToDTO(saved);
+    }
+
+    @Override
+    public CustomerTypeResponseDTO updateCustomerType(Long id, CustomerTypeRequestDTO requestDTO) {
+        CustomerType customerType = customerTypeRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Tipo de cliente no encontrado"));
+        if (!customerType.getName().equals(requestDTO.getName()) &&
+                customerTypeRepository.existsByName(requestDTO.getName())) {
+            throw new IllegalArgumentException("Ya existe un tipo de cliente con ese nombre");
+        }
+        customerType.setName(requestDTO.getName());
+        CustomerType updated = customerTypeRepository.save(customerType);
+        return mapToDTO(updated);
+    }
+
+    @Override
+    public void disableById(Long id) {
+        CustomerType type = customerTypeRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Tipo de cliente no encontrado"));
+        type.setActive(false);
+        customerTypeRepository.save(type);
+    }
+
+    @Override
+    public void enableById(Long id) {
+        CustomerType type = customerTypeRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Tipo de cliente no encontrado"));
+        type.setActive(true);
+        customerTypeRepository.save(type);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CustomerTypeResponseDTO getCustomerTypeById(Long id) {
+        CustomerType type = customerTypeRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Tipo de cliente no encontrado"));
+        return mapToDTO(type);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CustomerTypeResponseDTO> getAllCustomerTypes() {
+        return customerTypeRepository.findAll().stream()
+                .map(this::mapToDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CustomerTypeResponseDTO> getAllActiveCustomerTypes() {
+        return customerTypeRepository.findByActiveTrue().stream()
+                .map(this::mapToDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CustomerTypeResponseDTO getCustomerTypeByName(String name) {
+        CustomerType type = customerTypeRepository.findByName(name)
+                .orElseThrow(() -> new EntityNotFoundException("Tipo de cliente no encontrado"));
+        return mapToDTO(type);
+    }
+
+    private CustomerTypeResponseDTO mapToDTO(CustomerType customerType) {
+        return CustomerTypeResponseDTO.builder()
+                .id(customerType.getId())
+                .name(customerType.getName())
+                .active(customerType.getActive())
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- create DTOs for customers and customer types
- create service interfaces and implementations
- add CRUD controllers for customer and customer type entities
- extend repositories with additional queries

## Testing
- `./mvnw -q test` *(fails: Failed to fetch apache-maven)*

------
https://chatgpt.com/codex/tasks/task_e_6851d8aec5348325b968d4442476b08c